### PR TITLE
fix: remove Web tab and fix responsive layout issues

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -79,15 +79,15 @@ export const channels = {
     label: "Chrome",
     labelClass: "text-xs",
   },
-  web: {
-    href: "https://airdrop.vultisig.com/",
-    platform: null,
-    icon: "/images/vultiweb-logo.svg",
-    iconAlt: "Web App",
-    iconClass: "h-10 w-auto",
-    label: "Web App",
-    labelClass: "text-xs",
-  },
+  // web: {
+  //   href: "https://airdrop.vultisig.com/",
+  //   platform: null,
+  //   icon: "/images/vultiweb-logo.svg",
+  //   iconAlt: "Web App",
+  //   iconClass: "h-10 w-auto",
+  //   label: "Web App",
+  //   labelClass: "text-xs",
+  // },
 } as const
 
 export type ChannelKey = keyof typeof channels

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -12,7 +12,7 @@ import Gtag from "./Gtag"
 import { HashCard } from "./HashCard"
 import extensionPng from "./images/extension.png"
 import mobilePng from "./images/mobile.png"
-import webPng from "./images/web.png"
+// import webPng from "./images/web.png"
 
 const hashes = [
   {
@@ -40,10 +40,10 @@ const hashes = [
 const titleMap = {
   mobile: "Mobile App",
   browser: "Browser Extension",
-  web: "Web",
+  // web: "Web",
 }
 
-const tabs = ["mobile", "browser", "web"] as const
+const tabs = ["mobile", "browser"] as const
 
 export default async function DownloadsPage({
   searchParams,
@@ -116,16 +116,16 @@ const tabContentMap = {
       alt: "Vulticonnect Browser Extension Preview",
     },
   },
-  web: {
-    title: "Vultisig Web",
-    description:
-      "A view only access to your vault and register your Vaults for the airdrop.",
-    channels: ["web"] as const,
-    image: {
-      src: webPng,
-      alt: "Vultisig Web Preview",
-    },
-  },
+  // web: {
+  //   title: "Vultisig Web",
+  //   description:
+  //     "A view only access to your vault and register your Vaults for the airdrop.",
+  //   channels: ["web"] as const,
+  //   image: {
+  //     src: webPng,
+  //     alt: "Vultisig Web Preview",
+  //   },
+  // },
 }
 
 function TabContentDetail({ type }: { type: keyof typeof tabContentMap }) {

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -231,7 +231,7 @@ export default function HowItWorks() {
                 <span className="absolute top-4 right-5 text-7xl font-bold text-primaryBlue/10 leading-none">
                   {step.number}
                 </span>
-                <img src={step.icon} alt="" className="h-9 w-auto" />
+                <img src={step.icon} alt="" className="h-9 w-auto self-start" />
                 <h3 className="text-lg font-semibold text-white">
                   {step.title}
                 </h3>

--- a/components/cta-section.tsx
+++ b/components/cta-section.tsx
@@ -8,7 +8,7 @@ import DiscordSection from "./discord-section"
 export default function CtaSection() {
   return (
     <div className="container pb-10">
-      <section className="relative border border-borderLight rounded-2xl overflow-hidden md:aspect-[2.7/1] intersect-once intersect:motion-preset-slide-up-md">
+      <section className="relative border border-borderLight rounded-2xl overflow-hidden lg:aspect-[2.7/1] intersect-once intersect:motion-preset-slide-up-md">
         <Image
           src={bannerPng}
           alt="Banner background"

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -69,7 +69,7 @@ export default function Hero() {
           </div>
 
           {/* Right side — phone mockup */}
-          <div className="w-full max-h-[280px] sm:max-h-[400px] md:max-h-none lg:w-[53%] relative flex items-center justify-center lg:contents">
+          <div className="w-full max-h-[280px] sm:max-h-[400px] lg:max-h-none lg:w-[53%] relative flex items-center justify-center lg:contents">
             <HeroMockup />
           </div>
         </div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -11,7 +11,6 @@ import { ChevronDown, Menu, X } from "lucide-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
-import { HiOutlineComputerDesktop } from "react-icons/hi2"
 import { IoExtensionPuzzleOutline } from "react-icons/io5"
 import { LuTabletSmartphone } from "react-icons/lu"
 
@@ -50,7 +49,7 @@ export default function Navbar() {
       <nav
         className={cn(
           "fixed top-0 left-0 right-0 z-50 transition-all duration-300",
-          isAtTop ? "w-full bg-transparent px-0 pt-4" : "top-6 px-4 lg:px-2",
+          isAtTop ? "w-full bg-transparent px-0 pt-4" : "top-6 px-4 lg:px-2"
         )}
       >
         <div
@@ -59,7 +58,7 @@ export default function Navbar() {
             isAtTop
               ? "px-4 lg:px-8"
               : "border border-borderLight px-6 py-3 bg-foreground/5 backdrop-blur-md",
-            isOpen && "max-lg:bg-backgroundSecondary",
+            isOpen && "max-lg:bg-backgroundSecondary"
           )}
         >
           <div className="flex justify-between items-center">
@@ -106,7 +105,7 @@ export default function Navbar() {
               href="/downloads"
               className={cn(
                 buttonVariants({ variant: "primaryBlue" }),
-                "max-lg:hidden",
+                "max-lg:hidden"
               )}
             >
               Download App
@@ -141,7 +140,9 @@ export default function Navbar() {
                   >
                     <span>Products</span>
                     <ChevronDown
-                      className={`ml-1 size-4 transition-transform duration-200 ${mobileProductsOpen ? "rotate-180" : ""}`}
+                      className={`ml-1 size-4 transition-transform duration-200 ${
+                        mobileProductsOpen ? "rotate-180" : ""
+                      }`}
                     />
                   </button>
                   {mobileProductsOpen && (
@@ -170,7 +171,7 @@ export default function Navbar() {
                 href="/downloads"
                 className={cn(
                   buttonVariants({ variant: "primaryBlue" }),
-                  "mt-2 w-full",
+                  "mt-2 w-full"
                 )}
               >
                 Download App
@@ -195,7 +196,7 @@ function NavLinks() {
           className={cn(
             "text-textSecondary hover:text-white py-2",
             pathname.startsWith(link.href) &&
-              "text-white font-semibold tracking-wide",
+              "text-white font-semibold tracking-wide"
           )}
         >
           {link.name}
@@ -215,11 +216,6 @@ const products = [
     name: "Vultisig Extension",
     href: "/downloads?tab=browser",
     icon: IoExtensionPuzzleOutline,
-  },
-  {
-    name: "Vultisig Web",
-    href: "/downloads?tab=mobile",
-    icon: HiOutlineComputerDesktop,
   },
 ]
 

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -24,6 +24,11 @@ export default function Navbar() {
   const scrollTicking = useRef(false)
 
   useEffect(() => {
+    setIsOpen(false)
+    setMobileProductsOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
     const handleScroll = () => {
       if (scrollTicking.current) return
       scrollTicking.current = true


### PR DESCRIPTION
## Summary
- Remove the "Web" tab from `/downloads` page, leaving only Mobile App and Browser Extension (Closes #59)
- Close mobile nav menu automatically on route change (#60)
- Fix recovery section icon alignment across screen sizes (#61)
- Fix hero mockup overflow at 768–1024px viewport (#62)
- Fix CTA section content clipping at ~778px viewport (#63)
- Fix https://github.com/vultisig/vultisig-windows/issues/3665

## Test plan
- [ ] Verify `/downloads` page shows only Mobile App and Browser Extension tabs with correct styling and animations
- [ ] Verify mobile nav menu closes when clicking any menu item
- [ ] Verify recovery section icons stay left-aligned at all breakpoints
- [ ] Verify hero section has no overflow between 768–1024px
- [ ] Verify CTA section content is fully visible at ~778px
- [ ] Verify no regressions at larger screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)