### PR TITLE
perf: optimize LCP and reduce TBT on landing page

### DIFF
--- a/components/features-section.tsx
+++ b/components/features-section.tsx
@@ -64,7 +64,8 @@ export default function FeaturesSection() {
                   <img
                     src={feature.icon}
                     alt={`${feature.title} icon`}
-                    className="w-6 h-6"
+                    width={24}
+                    height={24}
                   />
                 </div>
                 <h3 className="text-[20px] font-semibold text-textPrimary tracking-tight">

--- a/components/hero-mockup.tsx
+++ b/components/hero-mockup.tsx
@@ -14,47 +14,52 @@ export default function HeroMockup() {
         alt="Hero Mockup"
         fill
         priority
-        sizes="(max-width: 1024px) 100vw, 53vw"
+        sizes="(max-width: 640px) 90vw, (max-width: 1024px) 80vw, 658px"
         className="absolute left-[4%] top-0 h-full object-contain"
       />
 
       <Image
         src="/images/hero/vault.svg"
-        alt="Phone Mockup"
+        alt="Vault screen"
         width={125}
         height={250}
+        loading="lazy"
         className="absolute right-[26.3%] top-[30.5%] w-[19%] h-auto"
       />
 
       <Image
         src="/images/hero/holding-vault.svg"
-        alt="Phone Mockup"
+        alt="Holding vault screen"
         width={145}
         height={290}
+        loading="lazy"
         className="absolute left-[25.6%] top-[22.5%] w-[22%] h-auto"
       />
 
       <Image
         src="/images/hero/swap.svg"
-        alt="Phone Mockup"
+        alt="Swap screen"
         width={178}
         height={350}
+        loading="lazy"
         className="absolute left-[12.3%] top-[33.5%] w-[27%] h-auto"
       />
 
       <Image
         src="/images/hero/waiting.svg"
-        alt="Phone Mockup"
+        alt="Waiting screen"
         width={184}
         height={360}
+        loading="lazy"
         className="absolute right-[14.3%] top-[47.5%] w-[28%] h-auto"
       />
 
       <Image
         src="/images/hero/qr.png"
-        alt="Phone Mockup"
+        alt="QR code screen"
         width={125}
         height={250}
+        loading="lazy"
         className="absolute left-[19.3%] top-[55.5%] w-[19%] h-auto"
       />
     </div>

--- a/components/sections/LoadTailwindIntersect.tsx
+++ b/components/sections/LoadTailwindIntersect.tsx
@@ -4,7 +4,13 @@ import { Observer } from "tailwindcss-intersect"
 
 export default function LoadTailwindIntersect() {
   useEffect(() => {
-    Observer.start()
+    if (typeof requestIdleCallback === "function") {
+      const id = requestIdleCallback(() => Observer.start())
+      return () => cancelIdleCallback(id)
+    } else {
+      const id = window.setTimeout(() => Observer.start(), 200)
+      return () => clearTimeout(id)
+    }
   }, [])
 
   return null

--- a/components/setup-section.tsx
+++ b/components/setup-section.tsx
@@ -57,8 +57,9 @@ export default function SetupSection() {
             <img
               src="/images/home-2.svg"
               alt="Fast Vault setup illustration"
-              width="400"
-              height="300"
+              width={400}
+              height={300}
+              loading="lazy"
               className="opacity-80 w-full lg:w-auto lg:max-w-[400px] h-auto object-contain"
             />
           </div>
@@ -112,8 +113,9 @@ export default function SetupSection() {
             <img
               src="/images/home-3.svg"
               alt="Secure Vault setup illustration"
-              width="400"
-              height="300"
+              width={400}
+              height={300}
+              loading="lazy"
               className="opacity-80 w-full lg:w-auto lg:max-w-[400px] h-auto object-contain"
             />
           </div>


### PR DESCRIPTION
## Summary
- Tighten hero `sizes` attribute from `100vw` to viewport-aware breakpoints — Next.js now serves smaller AVIF/WebP to mobile (640w vs 1516w)
- Lazy-load 5 non-critical hero overlay images — reduces bandwidth contention for LCP element
- Add native `loading="lazy"` to setup section SVG illustrations
- Defer `Observer.start()` via `requestIdleCallback` to eliminate forced reflow during page load
- Add proper `useEffect` cleanup for idle/timeout handles
- Add `width`/`height` to feature section icon `<img>` tags to prevent CLS

## Context
PageSpeed mobile score: 86. LCP at 3.0s (target <2.5s), TBT at 350ms (target <200ms). These changes target both metrics without touching source images — all format/size optimization happens via Next.js image pipeline.

## Test plan
- [x] `next build` compiles cleanly (no new warnings)
- [x] Browser QA: all 18 images render, 0 broken, 0 console errors
- [x] Lazy images load on scroll, intersection animations still trigger
- [x] Next.js auto-generates correct `<link rel="preload">` for hero via `priority` prop
- [x] Verified no quality loss — source PNG untouched, Next.js serves AVIF/WebP at correct responsive sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)