### PR TITLE
fix(mpc): wire up hero Download App and How It Works buttons

### DIFF
--- a/app/mpc/components/0_Hero.tsx
+++ b/app/mpc/components/0_Hero.tsx
@@ -6,6 +6,7 @@ import {
   DownloadIcon,
 } from "lucide-react"
 import Image from "next/image"
+import Link from "next/link"
 import { CiBag1 } from "react-icons/ci"
 import { IoPersonRemoveOutline } from "react-icons/io5"
 import heroImage from "../images/hero.png"
@@ -27,12 +28,16 @@ export default function Hero() {
             threshold signatures so your crypto stays yours.
           </p>
           <div className="flex gap-4 pt-4 motion-preset-slide-up-md motion-delay-400">
-            <Button variant={"primaryBlue"} className="md:h-12 md:px-8">
-              <DownloadIcon /> Download App
+            <Button asChild variant="primaryBlue" className="md:h-12 md:px-8">
+              <Link href="/downloads">
+                <DownloadIcon /> Download App
+              </Link>
             </Button>
-            <Button variant="secondary" className="md:h-12 md:px-8">
-              How It Works
-              <ArrowRightIcon />
+            <Button asChild variant="secondary" className="md:h-12 md:px-8">
+              <Link href="/how-it-works">
+                How It Works
+                <ArrowRightIcon />
+              </Link>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Both CTA buttons on /mpc were plain <Button> components with no href, onClick, or Link wrapper — clicks did nothing. Wrap each with Next.js <Link> via asChild so they route to /downloads and /how-it-works.

## Description

Fixes #{issue-number}

<!-- Brief description of what changed and why -->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test

## Agent Metadata

<!-- Auto-filled by agent. Leave blank for human PRs. -->
- Agent: <!-- agent name -->
- Issue: <!-- #number -->
- Rounds: <!-- feedback rounds addressed -->

## Checklist

- [ ] Tests pass locally
- [ ] Lint clean
- [ ] CodeRabbit feedback addressed
- [ ] Self-review done
- [ ] No secrets committed
- [ ] Conventional commit messages used
