### PR TITLE
fix(seo): strip markdown from article meta descriptions

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getArticleBySlug, getAllArticles } from "@/lib/articles"
+import { getArticleBySlug, getAllArticles, toMetaDescription } from "@/lib/articles"
 import { notFound } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
@@ -34,15 +34,17 @@ export async function generateMetadata({
       : `https://vultisig.com${article.image}`
     : undefined
 
+  const metaDescription = toMetaDescription(article.description)
+
   return {
     title: `${article.title} - Vultisig`,
-    description: article.description,
+    description: metaDescription,
     alternates: {
       canonical: url,
     },
     openGraph: {
       title: article.title,
-      description: article.description,
+      description: metaDescription,
       url,
       images: imageUrl ? [imageUrl] : [],
       type: "article",
@@ -54,7 +56,7 @@ export async function generateMetadata({
     twitter: {
       card: "summary_large_image",
       title: article.title,
-      description: article.description,
+      description: metaDescription,
       images: imageUrl ? [imageUrl] : [],
     },
   }
@@ -71,7 +73,7 @@ function ArticleJsonLd({
     "@context": "https://schema.org",
     "@type": "Article",
     headline: article.title,
-    description: article.description,
+    description: toMetaDescription(article.description),
     image: article.image
       ? article.image.startsWith("http")
         ? article.image

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -14,6 +14,31 @@ export interface Article {
   featured?: boolean
 }
 
+// Strip markdown, collapse whitespace, and truncate at a word boundary
+// so meta/og/twitter descriptions render cleanly in SERPs and social cards.
+export function toMetaDescription(raw: string, maxLen = 160): string {
+  if (!raw) return ''
+  const stripped = raw
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(?=\S)(.+?)(?<=\S)\1/g, '$2')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s{0,3}>\s?/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (stripped.length <= maxLen) return stripped
+  const slice = stripped.slice(0, maxLen)
+  const lastSpace = slice.lastIndexOf(' ')
+  const cut = lastSpace > maxLen * 0.6 ? slice.slice(0, lastSpace) : slice
+  return cut.replace(/[.,;:!?\s]+$/, '') + '…'
+}
+
 function validateSlug(slug: string): { valid: boolean; error?: string } {
   if (!slug?.trim()) return { valid: false, error: 'Slug cannot be empty' }
   if (!/^[a-z0-9-]+$/.test(slug)) {


### PR DESCRIPTION
## Summary

- `vultisig.com/articles/the-best-mpc-wallets-for-2026-a-deep-dive-into-self-custody-infrastructure` is currently serving `<meta name="description" content="In 2026, **Multi-Party Computation (MPC)** has ...">`. Raw `**asterisks**` show up in Google's SERP snippet and Twitter/OG cards.
- Root cause: `generateMetadata()` writes `article.description` straight from MongoDB into `description`, `openGraph.description`, `twitter.description`, and the JSON-LD `description` field — no sanitization, no length cap.
- Scope: 1 of 12 articles has markdown in the description today; 8 of 12 exceed the ~160-char SERP snippet cap.
- Fix: add a pure `toMetaDescription()` helper in `lib/articles.ts` that strips markdown (bold/italic/code/links/images/headings/blockquotes/lists/HTML), collapses whitespace, and truncates at a word boundary with an ellipsis. Apply it in the four description fields on the article detail page.
- MongoDB content is untouched. DB writes, admin form, listing page, API routes all unaffected. Sanitization is render-time only.

## Before / after for the offending article

**Before** (462 chars, raw markdown):
```
In 2026, **Multi-Party Computation (MPC)** has replaced the seed phrase as the standard for self-custody. Instead of a single private key, MPC uses **threshold cryptography** to split the key into 'shares' distributed across multiple devices. No single device ever holds the full key, and the key itself is never fully reconstructed during a transaction. This simple mathematical shift has made phishing-proof, phishing-resistant security accessible to everyone.
```

**After** (154 chars, clean):
```
In 2026, Multi-Party Computation (MPC) has replaced the seed phrase as the standard for self-custody. Instead of a single private key, MPC uses threshold…
```

## Follow-up (separate issue)

The raw markdown description for that one article is still in MongoDB. The render-time strip covers SERPs, but the DB field is still wrong. A separate issue has been opened so whoever owns the DB can update that row directly and optionally tighten the 8 over-length descriptions.

## Test plan

- [ ] Verify `npm run build` / `npx tsc --noEmit` passes (no new errors in changed files).
- [ ] On a preview deploy, view-source on `/articles/the-best-mpc-wallets-for-2026-a-deep-dive-into-self-custody-infrastructure` and confirm `<meta name="description">`, `<meta property="og:description">`, `<meta name="twitter:description">`, and JSON-LD `description` contain no `**` and are ≤ 161 chars (160 + ellipsis).
- [ ] Spot-check a short-description article (e.g. `self-custodial-automation-is-finally-here`) to confirm unchanged output when no markdown/overflow is present.
- [ ] Confirm article create/update via `/articles/admin` still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)