### PR TITLE
chore: add redirects for legacy marketing URLs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -49,6 +49,21 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/download/vultisig',
+        destination: '/downloads',
+        permanent: true,
+      },
+      {
+        source: '/technical-overview',
+        destination: '/how-it-works',
+        permanent: true,
+      },
+      {
+        source: '/security-features',
+        destination: '/mpc',
+        permanent: true,
+      },
+      {
         source: '/skills',
         destination: '/skills/SKILL.md',
         permanent: false,


### PR DESCRIPTION
## Summary
- Adds 308 permanent redirects to preserve SEO for retired URLs:
  - `/technical-overview` → `/how-it-works`
  - `/security-features` → `/mpc`
  - `/download/vultisig` → `/downloads`

## Test plan
- [ ] After deploy, `curl -sI https://vultisig.com/technical-overview | grep -i location` returns `/how-it-works`
- [ ] `curl -sI https://vultisig.com/security-features | grep -i location` returns `/mpc`
- [ ] `curl -sI https://vultisig.com/download/vultisig | grep -i location` returns `/downloads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)