### PR TITLE
allow Scout API to upload article images

### DIFF
--- a/app/api/articles/upload/route.ts
+++ b/app/api/articles/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { verifyAuthToken } from '@/lib/auth'
+import { canWriteArticles } from '@/lib/auth'
 import connectDB from '@/lib/mongodb'
 import { GridFSBucket } from 'mongodb'
 import mongoose from 'mongoose'
@@ -11,13 +11,8 @@ const error = (message: string, status = 500) => json({ message }, status)
 const MAX_SIZE = 1 * 1024 * 1024 // 1MB
 const MAX_DIMENSION = 1920 // Max width or height
 
-async function isAuthed(req: NextRequest): Promise<boolean> {
-  const token = req.cookies.get('admin_token')?.value
-  return token ? await verifyAuthToken(token) : false
-}
-
 export async function POST(req: NextRequest) {
-  if (!(await isAuthed(req))) {
+  if (!(await canWriteArticles(req))) {
     return error('Unauthorized', 401)
   }
 


### PR DESCRIPTION
## Summary
- `/api/articles/upload` only accepted the admin cookie (`admin_token`), blocking the Scout API key path.
- Replacing local `isAuthed()` with the shared `canWriteArticles()` from `lib/auth.ts` — same helper already used by `/api/articles` (POST/PUT/DELETE).
- Admin cookie continues to work; Scout Bearer key now works too.

## Why
- Agentic article publishing (e.g. the `vultisig-article` skill in Giga) uses the Scout API for create/update/delete but had to fall back to PR'ing static images into `public/images/articles/` because uploads were blocked.
- After this merges, agents can `POST /api/articles/upload` directly and reference the returned GridFS URL in the article's `image` field — matching the convention every existing article already uses.

## Files
- `app/api/articles/upload/route.ts` (1 import swap, 1 unused helper removed, 1 call site updated)

## Test plan
- [ ] curl -F file=@cover.png -H "Authorization: Bearer $SCOUT_KEY" https://vultisig.com/api/articles/upload returns 201 with `imageUrl`
- [ ] curl with admin_token cookie still returns 201
- [ ] curl with no auth returns 401
- [ ] Image renders correctly when referenced via `/api/articles/image/<id>` in an article