### PR TITLE
chore: update iOS version to v1.36.55 and update SHA256 checksum

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -26,7 +26,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "macos-github": {
-    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.35.50",
+    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.36.55",
     platform: "macos github",
     icon: "/images/macOS.svg",
     iconAlt: "MacOS Github",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -18,7 +18,7 @@ const hashes = [
   {
     os: "ios",
     icon: "/images/apple.svg",
-    hash: "sha256:65e9cb3536b819cfce613c61abf15b528f97688b85e3285893c7efda8a4c2d80",
+    hash: "sha256:12447987034cfc55d40a5148dd8490a2e0c964eb3f15823c585b2d5f4959cfb9",
   },
   {
     os: "android",


### PR DESCRIPTION
## Changes

- Updated iOS macOS GitHub release link to `v1.36.55`
- Updated iOS SHA256 checksum to `sha256:12447987034cfc55d40a5148dd8490a2e0c964eb3f15823c585b2d5f4959cfb9`