### PR TITLE
chore: update Windows/Linux download links and SHA256 hashes to v1.0.60

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.58/Vultisig-amd64-installer-v1.0.58.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.60/Vultisig-amd64-installer-v1.0.60.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.58/vultisig_1.0.58_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.60/vultisig_1.0.60_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -28,12 +28,12 @@ const hashes = [
   {
     os: "linux",
     icon: "/images/linux.svg",
-    hash: "sha256:71aa668802ad138087d522eb7d1d448b3a7c444fd6ebb845f366464945979050",
+    hash: "sha256:b4b26bd61a84ab1366f6844a9a46527225630193b505124cf4f2febc89056913",
   },
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:0dcbd43414d61c02973edf71b6e5b1f37173f899d018155275d710f9fb06ec95",
+    hash: "sha256:0862c498fa9745ebbea122c99f749dfc34b4cb663051539733fac003f9fd6e65",
   },
 ]
 


### PR DESCRIPTION
## What changed

- Updated Windows download URL to `v1.0.60` (`Vultisig-amd64-installer-v1.0.60.exe`)
- Updated Linux download URL to `v1.0.60` (`vultisig_1.0.60_amd64.deb`)
- Updated Windows SHA256 checksum to match the new release
- Updated Linux SHA256 checksum to match the new release

## Hashes

| Platform | SHA256 |
|----------|--------|
| Windows | `0862c498fa9745ebbea122c99f749dfc34b4cb663051539733fac003f9fd6e65` |
| Linux | `b4b26bd61a84ab1366f6844a9a46527225630193b505124cf4f2febc89056913` |

Hashes were computed by downloading the release assets directly from GitHub.