### PR TITLE
chore: update Android GitHub download link to v1.0.102

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.101",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.102",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",


### PR DESCRIPTION
## What changed

Updated the Android GitHub download link from `v1.0.101` to `v1.0.102` in `app/downloads/Gtag.tsx`.

## Why

New Android release `v1.0.102` is available on GitHub.