### PR TITLE
Harden article image routes

### DIFF
--- a/app/api/articles/auth/route.ts
+++ b/app/api/articles/auth/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
   response.cookies.set('admin_token', token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    sameSite: 'strict',
     maxAge: 60 * 60 * 24,
   })
 

--- a/app/api/articles/image/[id]/route.ts
+++ b/app/api/articles/image/[id]/route.ts
@@ -2,6 +2,51 @@ import { NextRequest, NextResponse } from 'next/server'
 import connectDB from '@/lib/mongodb'
 import { GridFSBucket } from 'mongodb'
 import mongoose from 'mongoose'
+import { canReadPrivateArticleImages } from '@/lib/auth'
+import Article from '@/lib/models/Article'
+
+const FALLBACK_IMAGE_CONTENT_TYPE = 'image/jpeg'
+const ALLOWED_IMAGE_CONTENT_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+])
+
+function getSafeImageContentType(contentType: string | undefined): string {
+  if (!contentType) return FALLBACK_IMAGE_CONTENT_TYPE
+
+  const normalizedContentType = contentType.toLowerCase()
+  if (!ALLOWED_IMAGE_CONTENT_TYPES.has(normalizedContentType)) {
+    return FALLBACK_IMAGE_CONTENT_TYPE
+  }
+
+  return normalizedContentType === 'image/jpg'
+    ? FALLBACK_IMAGE_CONTENT_TYPE
+    : normalizedContentType
+}
+
+function getGridFsContentType(file: { contentType?: string; metadata?: { contentType?: string } }): string {
+  return getSafeImageContentType(file.metadata?.contentType || file.contentType)
+}
+
+async function isReferencedByPublishedArticle(imagePath: string): Promise<boolean> {
+  const escapedImagePath = imagePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const publishedArticleQuery = {
+    $and: [
+      { $or: [{ status: 'published' }, { status: { $exists: false } }] },
+      {
+        $or: [
+          { image: imagePath },
+          { content: { $regex: escapedImagePath } },
+        ],
+      },
+    ],
+  }
+
+  return (await Article.exists(publishedArticleQuery)) !== null
+}
 
 export async function GET(
   req: NextRequest,
@@ -17,6 +62,10 @@ export async function GET(
     }
 
     const bucket = new GridFSBucket(db, { bucketName: 'article-images' })
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return new NextResponse('Image not found', { status: 404 })
+    }
+
     const objectId = new mongoose.Types.ObjectId(id)
     
     // First, check if file exists and get metadata
@@ -26,11 +75,16 @@ export async function GET(
     }
 
     const file = files[0]
-    const contentType = file.contentType || 'image/jpeg'
+    const contentType = getGridFsContentType(file)
+    const imagePath = `/api/articles/image/${id}`
+
+    if (!(await canReadPrivateArticleImages(req)) && !(await isReferencedByPublishedArticle(imagePath))) {
+      return new NextResponse('Image not found', { status: 404 })
+    }
     
     const downloadStream = bucket.openDownloadStream(objectId)
 
-    return new Promise((resolve) => {
+    return new Promise<NextResponse>((resolve) => {
       const chunks: Buffer[] = []
 
       downloadStream.on('data', (chunk: Buffer) => {
@@ -43,6 +97,8 @@ export async function GET(
         resolve(new NextResponse(buffer, {
           headers: {
             'Content-Type': contentType,
+            'X-Content-Type-Options': 'nosniff',
+            'Content-Security-Policy': "default-src 'none'; sandbox",
             'Cache-Control': 'public, max-age=31536000, immutable',
           },
         }))

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import type { Article } from '@/lib/articles'
 import { createArticle, updateArticle, deleteArticle, getAllArticles } from '@/lib/articles'
-import { canWriteArticles, isAdminAuthed } from '@/lib/auth'
+import { canAdminWriteArticles, canWriteArticles } from '@/lib/auth'
 
 const json = (data: any, status = 200) => NextResponse.json(data, { status })
 const error = (message: string, status = 500) => json({ message }, status)
@@ -93,7 +93,7 @@ export async function PUT(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!(await isAdminAuthed(req))) return error('Unauthorized', 401)
+  if (!(await canAdminWriteArticles(req))) return error('Unauthorized', 401)
 
   const slug = new URL(req.url).searchParams.get('slug')
   if (!slug) return error('Slug is required', 400)

--- a/app/api/articles/upload/route.ts
+++ b/app/api/articles/upload/route.ts
@@ -109,8 +109,8 @@ export async function POST(req: NextRequest) {
 
     const bucket = new GridFSBucket(db, { bucketName: 'article-images' })
     const uploadStream = bucket.openUploadStream(filename, {
-      contentType,
       metadata: {
+        contentType,
         originalName: file.name,
         originalSize: file.size,
         compressedSize: buffer.length,
@@ -118,7 +118,7 @@ export async function POST(req: NextRequest) {
       },
     })
 
-    return new Promise((resolve) => {
+    return new Promise<NextResponse>((resolve) => {
       uploadStream.end(buffer)
 
       uploadStream.on('finish', () => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -6,6 +6,48 @@ const JWT_SECRET = new TextEncoder().encode(
   (process.env.ADMIN_PASSWORD || '') + '-jwt-secret'
 )
 
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+function getForwardedHeaderValue(value: string | null): string | null {
+  return value?.split(',')[0]?.trim() || null
+}
+
+function getRequestOrigin(req: NextRequest): string {
+  const forwardedHost = getForwardedHeaderValue(req.headers.get('x-forwarded-host'))
+  const host = forwardedHost || req.headers.get('host')
+
+  if (!host) {
+    return new URL(req.url).origin
+  }
+
+  const forwardedProto = getForwardedHeaderValue(req.headers.get('x-forwarded-proto'))
+  const protocol = forwardedProto || new URL(req.url).protocol.replace(':', '')
+
+  return `${protocol}://${host}`
+}
+
+export function isSameOriginRequest(req: NextRequest): boolean {
+  const expectedOrigin = getRequestOrigin(req)
+  const origin = req.headers.get('origin')
+
+  if (origin) {
+    return origin === expectedOrigin
+  }
+
+  const referer = req.headers.get('referer')
+  if (!referer) return false
+
+  try {
+    return new URL(referer).origin === expectedOrigin
+  } catch {
+    return false
+  }
+}
+
+function isSafeAdminRequest(req: NextRequest): boolean {
+  return SAFE_METHODS.has(req.method) || isSameOriginRequest(req)
+}
+
 export async function createAuthToken(): Promise<string> {
   return new SignJWT({ authenticated: true })
     .setProtectedHeader({ alg: 'HS256' })
@@ -16,7 +58,7 @@ export async function createAuthToken(): Promise<string> {
 
 export async function verifyAuthToken(token: string): Promise<boolean> {
   try {
-    await jwtVerify(token, JWT_SECRET)
+    await jwtVerify(token, JWT_SECRET, { algorithms: ['HS256'] })
     return true
   } catch {
     return false
@@ -47,12 +89,20 @@ export async function isAdminAuthed(req: NextRequest): Promise<boolean> {
   return token ? verifyAuthToken(token) : false
 }
 
+export async function canAdminWriteArticles(req: NextRequest): Promise<boolean> {
+  return (await isAdminAuthed(req)) && isSafeAdminRequest(req)
+}
+
+export async function canReadPrivateArticleImages(req: NextRequest): Promise<boolean> {
+  return (await isAdminAuthed(req)) && isSameOriginRequest(req)
+}
+
 export function isScoutAuthed(req: NextRequest): boolean {
   const apiKey = getScoutApiKeyFromRequest(req)
   return apiKey ? verifyScoutApiKey(apiKey) : false
 }
 
 export async function canWriteArticles(req: NextRequest): Promise<boolean> {
-  if (await isAdminAuthed(req)) return true
+  if (await canAdminWriteArticles(req)) return true
   return isScoutAuthed(req)
 }


### PR DESCRIPTION
## Summary
- allowlist GridFS article image MIME types and add nosniff/CSP response headers
- store uploaded image MIME type in GridFS metadata while preserving legacy read fallback
- require same-origin admin-cookie write requests and set admin cookie SameSite=Strict
- explicitly verify admin JWTs with HS256 only
- scope public article image reads to images referenced by published articles; same-origin authenticated admins can still preview private draft images

## Issue
- Follow-up to Next image/cache-poisoning audit; no GitHub issue provided.

## Test Plan
- npm run build
- npx tsc --noEmit (touched API routes pass; existing unrelated errors remain in app/downloads/Gtag.tsx and components/rich-text-editor.tsx)
- npm run lint (fails because current script uses removed `next lint` command under this Next version)
- npm audit --omit=dev --json (no sharp finding; reports existing app-store-scraper/request/lodash/postcss advisories)

## Notes
- Production GridFS backfill audit still needs to be run with MONGODB_URI access.
- Article content renders through ReactMarkdown without rehypeRaw/dangerouslySetInnerHTML for raw content; no content sanitizer added in this PR.
