### PR TITLE
chore: update Android download link and SHA256 hash to v1.0.103

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.102",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.103",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:95851af9f164783246b80d0a7684a3613fdaa346c17d2534f3d4935e4000cbcf",
+    hash: "sha256:0e7e00fb74f8c2ee68d80eb54d71d4ee884f94909ce2ef2af059ceec807f793a",
   },
   {
     os: "linux",


### PR DESCRIPTION
## Summary

Updates the Android download version from v1.0.102 to v1.0.103.

### Changes
- **`app/downloads/Gtag.tsx`**: Updated Android GitHub release link to `v1.0.103`
- **`app/downloads/page.tsx`**: Updated Android SHA256 hash to match the new APK

### SHA256
`sha256:0e7e00fb74f8c2ee68d80eb54d71d4ee884f94909ce2ef2af059ceec807f793a`

Hash was computed directly from the APK downloaded at:
`https://github.com/vultisig/vultisig-android/releases/download/v1.0.103/v1.0.103.apk`