### PR TITLE
chore: update iOS/macOS download link and SHA256 hash to v1.37.57

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -26,7 +26,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "macos-github": {
-    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.36.55",
+    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.37.57",
     platform: "macos github",
     icon: "/images/macOS.svg",
     iconAlt: "MacOS Github",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -18,7 +18,7 @@ const hashes = [
   {
     os: "ios",
     icon: "/images/apple.svg",
-    hash: "sha256:12447987034cfc55d40a5148dd8490a2e0c964eb3f15823c585b2d5f4959cfb9",
+    hash: "sha256:3b395275042382387befd9b2a270c956d8b95723b813f66efcd5f500466891b1",
   },
   {
     os: "android",


### PR DESCRIPTION
## Summary

Updates the iOS/macOS download page to reflect the v1.37.57 release.

## Changes

- **`app/downloads/Gtag.tsx`** — Updated `macos-github` href from `v1.36.55` → `v1.37.57`
- **`app/downloads/page.tsx`** — Updated iOS/macOS SHA256 checksum to match the `VultisigApp.v1.37.57.signed.pkg` asset digest (`3b395275042382387befd9b2a270c956d8b95723b813f66efcd5f500466891b1`)

## Source

SHA256 hash sourced directly from the GitHub release asset digest: https://github.com/vultisig/vultisig-ios/releases/tag/v1.37.57