### PR TITLE
chore: update Windows/Linux download links and SHA256 hashes to v1.0.62

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.60/Vultisig-amd64-installer-v1.0.60.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.62/Vultisig-amd64-installer-v1.0.62.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.60/vultisig_1.0.60_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.62/vultisig_1.0.62_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -28,12 +28,12 @@ const hashes = [
   {
     os: "linux",
     icon: "/images/linux.svg",
-    hash: "sha256:b4b26bd61a84ab1366f6844a9a46527225630193b505124cf4f2febc89056913",
+    hash: "sha256:dfd3631f3916f80f6559ada376e275a67c5b0bb71a8a05f7fa553845c7f3b97c",
   },
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:0862c498fa9745ebbea122c99f749dfc34b4cb663051539733fac003f9fd6e65",
+    hash: "sha256:3350165ef3d2f3481498bd28bba31b821a5065f05aa0a25c60b0c4e24c6e4a73",
   },
 ]
 


### PR DESCRIPTION
## What changed

Updated the download page to point to the v1.0.62 release for Windows and Linux.

**`app/downloads/Gtag.tsx`**
- Windows installer URL: `Vultisig-amd64-installer-v1.0.60.exe` → `Vultisig-amd64-installer-v1.0.62.exe`
- Linux `.deb` URL: `vultisig_1.0.60_amd64.deb` → `vultisig_1.0.62_amd64.deb`

**`app/downloads/page.tsx`**
- Linux SHA256: updated to match `vultisig_1.0.62_amd64.deb` digest
- Windows SHA256: updated to match `Vultisig-amd64-installer-v1.0.62.exe` digest

Hashes sourced from the [v1.0.62 release assets](https://github.com/vultisig/vultisig-windows/releases/tag/v1.0.62).