### PR TITLE
chore: update Android download link and SHA256 hash to v1.0.107

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.103",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.107",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:0e7e00fb74f8c2ee68d80eb54d71d4ee884f94909ce2ef2af059ceec807f793a",
+    hash: "sha256:b842fbed48b1ecfe9c385378faf14cb7f4e756b88ac35663917c3dd93074f249",
   },
   {
     os: "linux",


### PR DESCRIPTION
Updates the Android GitHub download link and SHA256 checksum on the downloads page to v1.0.107.\n\n### Changes\n- `app/downloads/Gtag.tsx`: Updated `android-github` href from `v1.0.103` → `v1.0.107`\n- `app/downloads/page.tsx`: Updated Android SHA256 hash to `b842fbed48b1ecfe9c385378faf14cb7f4e756b88ac35663917c3dd93074f249` (sourced from the GitHub release asset digest)