### PR TITLE
downloads: update iOS/macOS to v1.38.59

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -26,7 +26,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "macos-github": {
-    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.37.57",
+    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.38.59",
     platform: "macos github",
     icon: "/images/macOS.svg",
     iconAlt: "MacOS Github",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -18,7 +18,7 @@ const hashes = [
   {
     os: "ios",
     icon: "/images/apple.svg",
-    hash: "sha256:3b395275042382387befd9b2a270c956d8b95723b813f66efcd5f500466891b1",
+    hash: "sha256:ca8f55ca3252a6358b2214bfcaf476dd11147771dbedebaac5a08328e34c965f",
   },
   {
     os: "android",


### PR DESCRIPTION
## Changes

- Updates the macOS GitHub download link from `v1.37.57` → `v1.38.59`
- Updates the iOS/macOS SHA256 hash to match the new release asset (`VultisigApp.v1.38.59.signed.pkg`)

## Files Changed

- `app/downloads/Gtag.tsx` — updated release tag URL
- `app/downloads/page.tsx` — updated SHA256 hash

## Hash source

Hash pulled from the GitHub release asset digest: https://github.com/vultisig/vultisig-ios/releases/tag/v1.38.59