### PR TITLE
downloads: update Windows download to v1.0.63

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.62/Vultisig-amd64-installer-v1.0.62.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.63/Vultisig-amd64-installer-v1.0.63.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.62/vultisig_1.0.62_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.63/vultisig_1.0.63_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -33,7 +33,7 @@ const hashes = [
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:3350165ef3d2f3481498bd28bba31b821a5065f05aa0a25c60b0c4e24c6e4a73",
+    hash: "sha256:a19c5d65444bc3d0476134d68768b6b874c7a47a54f1422801eab2421164aebf",
   },
 ]
 


### PR DESCRIPTION
## Summary

Updates the Windows (and Linux) download links on the downloads page from v1.0.62 to v1.0.63, and updates the Windows SHA256 checksum to match the new installer.

## Changes

- **`app/downloads/Gtag.tsx`**: Updated Windows installer URL to `Vultisig-amd64-installer-v1.0.63.exe`
- **`app/downloads/Gtag.tsx`**: Updated Linux `.deb` URL to `vultisig_1.0.63_amd64.deb`
- **`app/downloads/page.tsx`**: Updated Windows SHA256 checksum to `a19c5d65444bc3d0476134d68768b6b874c7a47a54f1422801eab2421164aebf`

## Verification

SHA256 was computed by downloading the release asset directly:
```
curl -sL https://github.com/vultisig/vultisig-windows/releases/download/v1.0.63/Vultisig-amd64-installer-v1.0.63.exe | shasum -a 256
a19c5d65444bc3d0476134d68768b6b874c7a47a54f1422801eab2421164aebf
```