### PR TITLE
[codex] Add Simple Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import localFont from "next/font/local"
 import { cn } from "@/lib/utils"
 import LoadTailwindIntersect from "@/components/sections/LoadTailwindIntersect"
 import TwitterAnalytics from "@/components/twitter-analytics"
+import Script from "next/script"
 
 const brockmann = localFont({
   style: "normal",
@@ -334,6 +335,7 @@ export default function RootLayout({
         <Toaster />
         <LoadTailwindIntersect />
       </body>
+      <Script src="https://scripts.simpleanalyticscdn.com/latest.js" />
     </html>
   )
 }


### PR DESCRIPTION
## What changed
- add the Simple Analytics script site-wide through Next.js Script in the root App Router layout
- use the default afterInteractive loading strategy recommended by Simple Analytics

## Why
This enables privacy-first traffic analytics across the marketing site.

## Validation
- npm run build