### PR TITLE
[codex] Fix article internal links and add glossary auto-linking

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -250,7 +250,10 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
               )}
             </div>
 
-            <MarkdownRenderer content={article.content} />
+            <MarkdownRenderer
+              content={article.content}
+              currentPath={`/articles/${article.slug}`}
+            />
           </article>
 
           <RelatedArticles articles={related} />

--- a/components/markdown-renderer.tsx
+++ b/components/markdown-renderer.tsx
@@ -109,8 +109,7 @@ export default function MarkdownRenderer({
             ),
             a: ({ href = "", children }) => {
               const internalHref = getInternalHref(href)
-              const className =
-                "text-blue-400 hover:text-blue-300 underline"
+              const className = "text-blue-400 hover:text-blue-300 underline"
 
               return internalHref ? (
                 <Link href={internalHref} className={className}>

--- a/components/markdown-renderer.tsx
+++ b/components/markdown-renderer.tsx
@@ -1,13 +1,19 @@
 "use client"
 
+import Link from "next/link"
 import ReactMarkdown from "react-markdown"
 import remarkBreaks from "remark-breaks"
+import { articleAutoLinks, getInternalHref } from "@/lib/article-auto-links"
 
 interface MarkdownRendererProps {
   content: string
+  currentPath?: string
 }
 
-export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
+export default function MarkdownRenderer({
+  content,
+  currentPath,
+}: MarkdownRendererProps) {
   // ULTIMATE SIMPLE FIX: Replace empty lines with a marker that creates visible spacing
   // Process line by line and inject spacing markers
 
@@ -37,7 +43,7 @@ export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
     <div className="max-w-none font-sans">
       <div className="text-textSecondary leading-relaxed">
         <ReactMarkdown
-          remarkPlugins={[remarkBreaks]}
+          remarkPlugins={[remarkBreaks, articleAutoLinks(currentPath)]}
           components={{
             h1: ({ children }) => (
               <h1 className="text-3xl font-bold text-white mt-8 mb-4">
@@ -101,16 +107,26 @@ export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
             li: ({ children }) => (
               <li className="text-textSecondary mb-1">{children}</li>
             ),
-            a: ({ href, children }) => (
-              <a
-                href={href}
-                className="text-blue-400 hover:text-blue-300 underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {children}
-              </a>
-            ),
+            a: ({ href = "", children }) => {
+              const internalHref = getInternalHref(href)
+              const className =
+                "text-blue-400 hover:text-blue-300 underline"
+
+              return internalHref ? (
+                <Link href={internalHref} className={className}>
+                  {children}
+                </Link>
+              ) : (
+                <a
+                  href={href}
+                  className={className}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {children}
+                </a>
+              )
+            },
             code: ({ children }) => (
               <code className="bg-slate-800 px-2 py-1 rounded text-sm text-blue-300 font-mono">
                 {children}

--- a/lib/article-auto-links.ts
+++ b/lib/article-auto-links.ts
@@ -43,20 +43,19 @@ function collectExistingTargets(node: MarkdownNode, targets: Set<string>) {
   node.children?.forEach((child) => collectExistingTargets(child, targets))
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 function findFirstGlossaryMatch(value: string, usedTargets: Set<string>) {
-  let bestMatch:
-    | { index: number; match: string; href: string }
-    | undefined
+  let bestMatch: { index: number; match: string; href: string } | undefined
 
   for (const entry of glossary) {
     if (usedTargets.has(entry.href)) continue
 
     for (const term of entry.terms) {
-      const match = new RegExp(`\\b${term}\\b`, "i").exec(value)
-      if (
-        match &&
-        (!bestMatch || match.index < bestMatch.index)
-      ) {
+      const match = new RegExp(`\\b${escapeRegExp(term)}\\b`, "i").exec(value)
+      if (match && (!bestMatch || match.index < bestMatch.index)) {
         bestMatch = {
           index: match.index,
           match: match[0],

--- a/lib/article-auto-links.ts
+++ b/lib/article-auto-links.ts
@@ -1,0 +1,124 @@
+const AUTO_LINK_LIMIT = 4
+
+const glossary = [
+  { terms: ["MPC wallet", "multi-party computation wallet"], href: "/mpc" },
+  { terms: ["seedless wallet", "seedless wallets"], href: "/mpc" },
+]
+
+type MarkdownNode = {
+  type: string
+  value?: string
+  url?: string
+  children?: MarkdownNode[]
+}
+
+const skippedNodeTypes = new Set([
+  "code",
+  "heading",
+  "html",
+  "inlineCode",
+  "link",
+  "linkReference",
+])
+
+export function getInternalHref(href: string) {
+  if (href.startsWith("/") && !href.startsWith("//")) return href
+
+  try {
+    const url = new URL(href)
+    return url.origin === "https://vultisig.com"
+      ? `${url.pathname}${url.search}${url.hash}`
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function collectExistingTargets(node: MarkdownNode, targets: Set<string>) {
+  if (node.type === "link" && node.url) {
+    const href = getInternalHref(node.url)
+    if (href) targets.add(href)
+  }
+
+  node.children?.forEach((child) => collectExistingTargets(child, targets))
+}
+
+function findFirstGlossaryMatch(value: string, usedTargets: Set<string>) {
+  let bestMatch:
+    | { index: number; match: string; href: string }
+    | undefined
+
+  for (const entry of glossary) {
+    if (usedTargets.has(entry.href)) continue
+
+    for (const term of entry.terms) {
+      const match = new RegExp(`\\b${term}\\b`, "i").exec(value)
+      if (
+        match &&
+        (!bestMatch || match.index < bestMatch.index)
+      ) {
+        bestMatch = {
+          index: match.index,
+          match: match[0],
+          href: entry.href,
+        }
+      }
+    }
+  }
+
+  return bestMatch
+}
+
+export function articleAutoLinks(currentPath?: string) {
+  return () => (tree: MarkdownNode) => {
+    const usedTargets = new Set<string>()
+    const currentHref = currentPath && getInternalHref(currentPath)
+    if (currentHref) usedTargets.add(currentHref)
+    collectExistingTargets(tree, usedTargets)
+
+    let autoLinkCount = 0
+
+    const transform = (node: MarkdownNode) => {
+      if (!node.children || skippedNodeTypes.has(node.type)) return
+
+      const children: MarkdownNode[] = []
+
+      for (const child of node.children) {
+        if (child.type !== "text" || !child.value) {
+          transform(child)
+          children.push(child)
+          continue
+        }
+
+        let remaining = child.value
+
+        while (remaining && autoLinkCount < AUTO_LINK_LIMIT) {
+          const match = findFirstGlossaryMatch(remaining, usedTargets)
+          if (!match) break
+
+          if (match.index > 0) {
+            children.push({
+              type: "text",
+              value: remaining.slice(0, match.index),
+            })
+          }
+
+          children.push({
+            type: "link",
+            url: match.href,
+            children: [{ type: "text", value: match.match }],
+          })
+          usedTargets.add(match.href)
+          autoLinkCount += 1
+          remaining = remaining.slice(match.index + match.match.length)
+        }
+
+        if (remaining) children.push({ type: "text", value: remaining })
+      }
+
+      node.children = children
+    }
+
+    transform(tree)
+  }
+}


### PR DESCRIPTION
## Summary
- render same-origin article links with Next `Link` in the same tab
- preserve the current new-tab behavior and safety attributes for external links
- add a render-time glossary auto-linker for article Markdown
- pass the current article path into the renderer to prevent future self-links

## Glossary automation
This implements approach B from #95 with conservative guardrails:
- links only the first matching occurrence for each destination
- skips headings, inline/fenced code, HTML, and existing links
- does not duplicate destinations already linked by the author
- skips the current article path
- caps generated links at 4 per article

The initial curated glossary targets the existing `/mpc` pillar for `MPC wallet`, `multi-party computation wallet`, and `seedless wallet` terminology. When `/agentic-wallet` and `/seedless-wallet` exist, they can be added to the glossary map without editing MongoDB article content.

This removes the need for a manual MongoDB editorial pass for glossary terms. Curated article-to-article mappings can be added to the same glossary as a follow-up once target articles are selected.

## Root cause
The Markdown renderer treated every link as external, forcing `target="_blank"` and `rel="noopener noreferrer"`. Article content is stored in MongoDB, so contextual links otherwise required a manual editorial pass.

## Validation
- `npm run build` passes
- `git diff --check` passes
- `npx tsc --noEmit` still reports pre-existing errors in `app/downloads/Gtag.tsx` and `components/rich-text-editor.tsx`; this change introduces no new TypeScript errors

Partially addresses #95: implements the renderer prerequisite and glossary auto-linking approach. Cross-article target curation remains a content/SEO decision.
