### PR TITLE
[codex] Allow Simple Analytics in CSP

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,11 +12,11 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.ads-twitter.com https://cdn.markfi.xyz https://static.cloudflareinsights.com",
+      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.ads-twitter.com https://cdn.markfi.xyz https://static.cloudflareinsights.com https://scripts.simpleanalyticscdn.com",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https: blob:",
       "font-src 'self'",
-      "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://api.rss2json.com https://api.coingecko.com https://*.vultisig.com https://*.markfi.xyz https://cloudflareinsights.com https://static.cloudflareinsights.com",
+      "connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://api.rss2json.com https://api.coingecko.com https://*.vultisig.com https://*.markfi.xyz https://cloudflareinsights.com https://static.cloudflareinsights.com https://queue.simpleanalyticscdn.com",
       "frame-ancestors 'self'",
     ].join('; '),
   },


### PR DESCRIPTION
## What changed
- allow the Simple Analytics CDN in the Content Security Policy script sources
- allow the Simple Analytics queue endpoint for beacon requests

## Why
The Simple Analytics script is present in the deployed HTML, but the site's CSP blocks the browser from executing it.

## Validation
- npm run build
- confirmed live CSP currently omits both required Simple Analytics origins