### PR TITLE
[codex] fix missing article fallback image

### DIFF
--- a/components/medium-section.tsx
+++ b/components/medium-section.tsx
@@ -68,7 +68,7 @@ function ArticleCard({
     <>
       <div className="aspect-video bg-slate-700 rounded-xl mb-4 sm:mb-6 overflow-hidden">
         <img
-          src={article.image || "/images/placeholder-article.svg"}
+          src={article.image || "/images/home-5.svg"}
           alt={article.title}
           width="800"
           height="450"


### PR DESCRIPTION
## What changed

- use the existing `/images/home-5.svg` asset when an article has no image

## Why

The previous fallback referenced `/images/placeholder-article.svg`, which does not exist and returns 404.

## Validation

- confirmed `public/images/home-5.svg` exists
- `npm.cmd run build`
- `git diff --check`

## Not changed

- no guessed redirect was added for `/articles/what-is-a-seedless-wallet`; its intended replacement is unknown
