### PR TITLE
downloads: update Android to v1.0.108

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.107",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.108",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:b842fbed48b1ecfe9c385378faf14cb7f4e756b88ac35663917c3dd93074f249",
+    hash: "sha256:bd318a795788e393a99df2e37ee7a40d6e06dd3eb8545bc6fc8f551e9e08086f",
   },
   {
     os: "linux",


### PR DESCRIPTION
## What changed

- Updated Android GitHub release link to `v1.0.108` in `app/downloads/Gtag.tsx`
- Updated Android SHA256 hash to `bd318a795788e393a99df2e37ee7a40d6e06dd3eb8545bc6fc8f551e9e08086f` in `app/downloads/page.tsx`

Hash sourced directly from the GitHub release asset `digest` field for [v1.0.108](https://github.com/vultisig/vultisig-android/releases/tag/v1.0.108).