### PR TITLE
skills/llms: surface CLI agent ask + non-TTY mode; fix inaccurate CLI examples

### DIFF
--- a/public/.well-known/agent.json
+++ b/public/.well-known/agent.json
@@ -13,7 +13,8 @@
     "vault-management",
     "token-approvals",
     "cross-chain-swaps",
-    "automated-trading"
+    "automated-trading",
+    "natural-language-agent-interface"
   ],
   "supported_chains": {
     "utxo": ["Bitcoin", "Litecoin", "Dogecoin", "BitcoinCash", "Dash", "Zcash"],
@@ -27,6 +28,15 @@
     "install": "npm install @vultisig/sdk",
     "repository": "https://github.com/vultisig/vultisig-sdk",
     "documentation": "https://github.com/vultisig/vultisig-sdk/blob/main/docs/SDK-USERS-GUIDE.md"
+  },
+  "cli": {
+    "package": "@vultisig/cli",
+    "install": "npm install -g @vultisig/cli",
+    "bin": "vultisig",
+    "natural_language_command": "vultisig agent ask \"<message>\"",
+    "non_interactive": "Auto-detects non-TTY environments and skips prompts that would hang an agent",
+    "output": "Structured JSON via -o json, with stable exit codes and error codes",
+    "documentation": "https://vultisig.com/skills/vultisig-cli/SKILL.md"
   },
   "agent_resources": {
     "llms_txt": "https://vultisig.com/llms.txt",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -16,7 +16,7 @@ Two vault types:
 - [Agent Integration Guide](https://github.com/vultisig/vultisig-sdk/blob/main/AGENTS.md): Comprehensive guide written for AI agent integration
 - [SDK Users Guide](https://github.com/vultisig/vultisig-sdk/blob/main/docs/SDK-USERS-GUIDE.md): Full API walkthrough — vault types, operations, events, caching
 - [Architecture](https://github.com/vultisig/vultisig-sdk/blob/main/docs/architecture/ARCHITECTURE.md): SDK internals, data flow, design patterns
-- [CLI Tool](https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli): `vsig vault create`, `vsig send`, `vsig swap`
+- [CLI Tool](https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli): `vultisig create fast`, `vultisig send`, `vultisig swap`, plus natural-language `vultisig agent ask` for AI-to-AI use
 - [SKILL.md](https://vultisig.com/SKILL.md): Step-by-step operating procedure with exact SDK method signatures and code examples
 
 ## Agent Quick Start
@@ -177,19 +177,22 @@ const vaultId = await sdk.createFastVaultFromSeedphrase({
 # Source: clients/cli/ — https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli
 
 # Install CLI globally
-npm install -g @vultisig/sdk
+npm install -g @vultisig/cli
 
-# Create vault
-vsig vault create --name agent-vault --type fast
+# Create a Fast Vault (non-TTY auto-detects and skips interactive prompts)
+vultisig create fast --name agent-vault --email agent@example.com --password "$VAULT_PASSWORD" -o json
 
-# Check balance
-vsig balance --chain Ethereum
+# Check balance (positional chain arg, case-insensitive)
+vultisig balance ethereum -o json
 
 # Send transaction
-vsig send --chain Ethereum --to 0x... --amount 0.1
+vultisig send ethereum 0xRecipient 0.1 --password "$VAULT_PASSWORD" -y -o json
 
-# Swap
-vsig swap --from ETH --to USDC --amount 0.1
+# Swap (positional from/to chains)
+vultisig swap ethereum bitcoin 0.1 --password "$VAULT_PASSWORD" -y -o json
+
+# Natural-language, one-shot — built for AI agent integration
+vultisig agent ask "What is my ETH balance?" --password "$VAULT_PASSWORD" --json
 ```
 
 ## Key Concepts

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,7 +8,7 @@
 - [SDK Source](https://github.com/vultisig/vultisig-sdk): Monorepo with SDK, CLI, core libraries, and examples
 - [Agent Integration Guide](https://github.com/vultisig/vultisig-sdk/blob/main/AGENTS.md): Comprehensive guide for AI agent integration
 - [SDK Users Guide](https://github.com/vultisig/vultisig-sdk/blob/main/docs/SDK-USERS-GUIDE.md): Full API walkthrough — vault types, operations, events, caching
-- [CLI Tool](https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli): Command-line vault management — `vsig vault create`, `vsig send`, `vsig swap`
+- [CLI Tool](https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli): Command-line wallet for agents — `vultisig create fast`, `vultisig send`, `vultisig swap`, plus a natural-language `vultisig agent ask` mode for AI-to-AI use. JSON output, stable exit codes, and non-interactive auto-detection.
 - [SKILL.md](https://vultisig.com/SKILL.md): Step-by-step operating procedure with exact SDK method signatures and code examples
 
 ## Fast Vault (Agent Wallets)

--- a/public/skills/vultisig-cli/SKILL.md
+++ b/public/skills/vultisig-cli/SKILL.md
@@ -122,6 +122,8 @@ vultisig swap ethereum bitcoin 0.1 --password "SecurePass123!" -y -o json
 | `portfolio -o json` | Total portfolio value in fiat |
 | `send <chain> <to> <amount>` | Send native token |
 | `send <chain> <to> <amount> --token <addr>` | Send ERC-20 token |
+| `agent ask "<message>"` | One-shot natural-language mode for AI agents (see [AI Agent Integration](#ai-agent-integration)) |
+| `agent` / `agent --via-agent` | Interactive chat TUI / NDJSON agent-to-agent pipe |
 
 ### Swap Operations
 
@@ -166,6 +168,52 @@ vultisig send ethereum 0x... 0.1 -y --password "pass" -o json
 vultisig info -o json
 # {"vault":{"id":"...","name":"...","type":"fast","chains":[...]}}
 ```
+
+## AI Agent Integration
+
+The CLI is built to run inside agents. Beyond the structured commands above, it offers a natural-language mode and runs unattended without hanging on prompts.
+
+### Non-interactive by default
+
+In a non-TTY environment (pipes, scripts, agents), the CLI auto-detects this and skips interactive prompts. Vault creation falls back to two-step mode automatically:
+
+```bash
+# Auto-detects non-TTY, skips the interactive OTP prompt, returns immediately
+vultisig create fast --name "agent-wallet" --email "agent@example.com" --password "$VAULT_PASSWORD" -o json
+
+# Verify later, once you have the email code
+vultisig verify <vaultId> --code 123456
+```
+
+Use `--ci` for full automation mode (equivalent to `--output json --non-interactive --quiet`). Supply the password through `--password` or `VAULT_PASSWORD` so no command blocks on input.
+
+### Agent ask (natural language)
+
+Send a single natural-language message and get a structured response. This mode is designed for AI-to-AI use and routes through the Vultisig agent backend.
+
+```bash
+# Query
+vultisig agent ask "What is my ETH balance?" --password "$VAULT_PASSWORD"
+
+# Execute a transaction
+vultisig agent ask "Send 0.01 ETH to 0x742d..." --password "$VAULT_PASSWORD"
+
+# Continue a conversation, structured JSON for parsing
+vultisig agent ask "Now swap it to USDC" --session abc123 --password "$VAULT_PASSWORD" --json
+```
+
+```json
+{
+  "session_id": "abc123-def456",
+  "response": "Your ETH balance is 1.5 ETH ($3,750.00 USD).",
+  "tool_calls": [{ "action": "get_balances", "success": true }],
+  "transactions": [{ "hash": "0x9f8e...", "chain": "ethereum", "explorerUrl": "https://etherscan.io/tx/0x9f8e..." }]
+}
+```
+
+On failure, stdout is a single JSON object with a human-readable `error` and a stable `code` (for example `BACKEND_UNREACHABLE`, `AUTH_FAILED`, `VAULT_LOCKED`). Branch on `code`, not on the message.
+
+For an interactive chat TUI or NDJSON agent-to-agent piping, use `vultisig agent` and `vultisig agent --via-agent`.
 
 ## Common Workflows
 


### PR DESCRIPTION
## What changed

The website's agent-discovery layer (`/skills`, `llms.txt`, `llms-full.txt`, `agent.json`) routed agents to the CLI but never surfaced its agent-native features, and the CLI examples were inaccurate.

- **`skills/vultisig-cli/SKILL.md`** — add an **AI Agent Integration** section: non-interactive (non-TTY) default, `agent ask` natural-language mode, agent chat/pipe mode, and stable error codes. Add Core Commands rows for `agent ask` / `agent`.
- **`llms.txt` / `llms-full.txt`** — replace the non-existent `vsig vault create --type fast` and wrong `--chain` / `--from` flags with the real commands (positional args, `@vultisig/cli` install). An agent following the old block would have failed. Add `agent ask`.
- **`.well-known/agent.json`** — add a `cli` object alongside `sdk` and a `natural-language-agent-interface` capability.

## Why

`vultisig agent ask` (one-shot, AI-to-AI) and the non-TTY auto-detection are the CLI's strongest agent features, and were absent from every agent-facing surface on the site. The CLI examples in `llms*.txt` also did not match the shipped command interface.

## receipts

no runtime changes (static files under `public/` — skill markdown, llms text, agent manifest).

Verification performed:
- `python3 -m json.tool public/.well-known/agent.json` → VALID JSON
- `git diff --check` → clean (no whitespace errors)
- All commands, flags, the `abe.vultisig.com` backend, and error codes verified against `vultisig-sdk` `clients/cli/src/index.ts` and `clients/cli/README.md`

Pairs with vultisig/docs#82 (same gap fixed in the docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)