### PR TITLE
Update iOS/macOS to v1.39.61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+.npm-cache/
 
 # next.js
 /.next/

--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -26,7 +26,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "macos-github": {
-    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.38.59",
+    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.39.61",
     platform: "macos github",
     icon: "/images/macOS.svg",
     iconAlt: "MacOS Github",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -18,7 +18,7 @@ const hashes = [
   {
     os: "ios",
     icon: "/images/apple.svg",
-    hash: "sha256:ca8f55ca3252a6358b2214bfcaf476dd11147771dbedebaac5a08328e34c965f",
+    hash: "sha256:b8d8a3e6eb5f2528fa53893382675a86a6db90f0fc1ea9c0d353ee56fbfa178e",
   },
   {
     os: "android",


### PR DESCRIPTION
Update download links and hashes for iOS and macOS to reflect the latest version v1.39.61.