### PR TITLE
Use marketing@vultisig.com as RSS feed author email

### DIFF
--- a/app/articles/feed.xml/route.ts
+++ b/app/articles/feed.xml/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
       <guid isPermaLink="true">${url}</guid>
       <description><![CDATA[${article.description}]]></description>
       <pubDate>${pubDate}</pubDate>
-      <author>hello@vultisig.com (${article.author})</author>
+      <author>marketing@vultisig.com (${article.author})</author>
       ${article.tags?.map(tag => `<category>${tag}</category>`).join('\n      ') || ''}
     </item>`
     })


### PR DESCRIPTION
## What
Change the `<author>` email in the articles RSS feed (`/articles/feed.xml`) from `hello@vultisig.com` to `marketing@vultisig.com`.

## Why
The feed hardcoded `hello@vultisig.com` for every item's author field. Marketing owns the article/RSS surface, so the feed should reference the marketing inbox.

## Scope
- One line in `app/articles/feed.xml/route.ts`.
- Confirmed via repo-wide grep that this was the only `hello@vultisig.com` reference in code — no other surfaces (footer, contact, structured data) touched.

## receipts
Rendered the updated `<author>` template literal with a sample article — produces the correct address:
```
$ node -e 'const article={author:"Vultisig"}; console.log(`      <author>marketing@vultisig.com (${article.author})</author>`)'
      <author>marketing@vultisig.com (Vultisig)</author>
```
Live feed still serves the old value (cached `s-maxage=3600`, reflects ~1h after deploy):
```
$ curl -s https://vultisig.com/articles/feed.xml | grep -m1 "<author>"
      <author>hello@vultisig.com (Vultisig)</author>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)