### PR TITLE
fix: remove duplicate logo.svg og:image

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,13 +72,6 @@ export const metadata: Metadata = {
         alt: "Vultisig - The Safest Crypto Wallet | Seedless Security Made Simple",
         type: "image/png",
       },
-      {
-        url: "https://vultisig.com/logo.svg",
-        width: 512,
-        height: 512,
-        alt: "Vultisig Logo",
-        type: "image/svg+xml",
-      },
     ],
     countryName: "British Virgin Islands",
   },


### PR DESCRIPTION
## What
Removes the duplicate `logo.svg` entry from `metadata.openGraph.images` in `app/layout.tsx`. The correct 1200×630 `/thumbnails/home.png` social card stays.

## Why
Found during an SEO audit of vultisig.com — the homepage emitted **two** `og:image` tags. SVG isn't a valid social-card image and some scrapers select the *last* `og:image`, so shares could render the 512px logo instead of the proper card. Only the PNG should be advertised.

## receipts
- `npm run build` → **exit 0**, full static export, all routes prerendered (incl. `/` and `sitemap-*`)
- `git diff` → **7 lines deleted, `app/layout.tsx` only**
- Untouched and verified intact: `<link rel="canonical">`, `twitter:image`, the `icons`/`msapplication-*` logo refs, and JSON-LD
- Note: `npm run lint` is broken repo-wide (`next lint` was removed in Next 16) — pre-existing, out of scope for this one-line change

🤖 Generated with [Claude Code](https://claude.com/claude-code)