### PR TITLE
downloads: update Android to v1.0.109

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.108",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.109",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:bd318a795788e393a99df2e37ee7a40d6e06dd3eb8545bc6fc8f551e9e08086f",
+    hash: "sha256:82a9f7591a7306cb22ac3c569484b0e605635a425e814ebd27ef3297db502af7",
   },
   {
     os: "linux",


### PR DESCRIPTION
## Changes

Updates the Android Vultisig app to the latest version v1.0.109 on the downloads page.

### Updates

- **Gtag.tsx**: Updated Android GitHub release link from `v1.0.108` → `v1.0.109`
- **page.tsx**: Updated Android SHA256 checksum to `82a9f7591a7306cb22ac3c569484b0e605635a425e814ebd27ef3297db502af7` (from the official release digest)

### What's New in v1.0.109

This release includes improvements to swap functionality, keysign flows, and various bug fixes. Key updates include:
- Advanced Swap UI (Market/Limit tabs)
- TON DEX swap decoding for dApp keysign
- TON native token rebranding to GRAM
- Security and stability improvements across multiple chains
- Gradle wrapper upgrade to 8.14.4

See the [full changelog](https://github.com/vultisig/vultisig-android/releases/tag/v1.0.109) for complete details.