### PR TITLE
downloads: update Windows/Linux to v1.0.66 and SHA256 hashes

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.63/Vultisig-amd64-installer-v1.0.63.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.66/Vultisig-amd64-installer-v1.0.66.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.63/vultisig_1.0.63_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.66/vultisig_1.0.66_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -28,12 +28,12 @@ const hashes = [
   {
     os: "linux",
     icon: "/images/linux.svg",
-    hash: "sha256:dfd3631f3916f80f6559ada376e275a67c5b0bb71a8a05f7fa553845c7f3b97c",
+    hash: "sha256:af1d4cd891b01a42326857201f247eb90502ad6698382ca85d9b1df3a0fc1c9a",
   },
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:a19c5d65444bc3d0476134d68768b6b874c7a47a54f1422801eab2421164aebf",
+    hash: "sha256:207564b634bb0a2074dea0362e95dd9db5ce955e42da67ae64698b3fa1c04520",
   },
 ]
 


### PR DESCRIPTION
## Summary
- Update Windows download link and SHA256 hash to v1.0.66
- Update Linux download link and SHA256 hash to v1.0.66

## Details
| Platform | Asset | SHA256 |
|----------|-------|--------|
| Windows | `Vultisig-amd64-installer-v1.0.66.exe` | `207564b634bb0a2074dea0362e95dd9db5ce955e42da67ae64698b3fa1c04520` |
| Linux | `vultisig_1.0.66_amd64.deb` | `af1d4cd891b01a42326857201f247eb90502ad6698382ca85d9b1df3a0fc1c9a` |

Both hashes were verified by downloading the actual release assets and computing the checksums locally.