### PR TITLE
downloads: update Android release and SHA256 to v1.0.113

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.111",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.113",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:a3c11d722e7ae6f60b75ec5473d979adfa9b4ef7c0de0bf25094b3b1c23c4f7f",
+    hash: "sha256:49ecbf312b461f4c4109732097a6dbb45fc5e77d43ddab7ec89e6da8e1166244",
   },
   {
     os: "linux",


### PR DESCRIPTION
## Summary
- update Android GitHub download link on the downloads page to `v1.0.113`
- update Android SHA256 checksum to match the `v1.0.113.apk` GitHub release asset digest

## Why
Keep the website download metadata aligned with the latest Android release so users get the correct release link and integrity checksum.

## Notes for reviewers
- SHA256 was sourced from the `vultisig/vultisig-android` GitHub release `v1.0.113` asset metadata (`v1.0.113.apk`).