### PR TITLE
downloads: update Windows and Linux to v1.0.67

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.66/Vultisig-amd64-installer-v1.0.66.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.67/Vultisig-amd64-installer-v1.0.67.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.66/vultisig_1.0.66_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.67/vultisig_1.0.67_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -28,12 +28,12 @@ const hashes = [
   {
     os: "linux",
     icon: "/images/linux.svg",
-    hash: "sha256:af1d4cd891b01a42326857201f247eb90502ad6698382ca85d9b1df3a0fc1c9a",
+    hash: "sha256:f8413d34c02e9d8737f14b237fde2c6a4d3dfe72425f6777185adb7e44843d8b",
   },
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:207564b634bb0a2074dea0362e95dd9db5ce955e42da67ae64698b3fa1c04520",
+    hash: "sha256:11875299a204e6761754c583293d219353a1d981a654177ace300dbe387afa93",
   },
 ]
 


### PR DESCRIPTION
## Summary
Updates the Windows and Linux desktop downloads to release **v1.0.67**.

### Changes
- **Download URLs** (`app/downloads/Gtag.tsx`)
  - Windows → `Vultisig-amd64-installer-v1.0.67.exe`
  - Linux → `vultisig_1.0.67_amd64.deb`
- **SHA256 checksums** (`app/downloads/page.tsx`)
  - Windows → `11875299a204e6761754c583293d219353a1d981a654177ace300dbe387afa93`
  - Linux → `f8413d34c02e9d8737f14b237fde2c6a4d3dfe72425f6777185adb7e44843d8b`

Hashes were taken from the `digest` field of the v1.0.67 assets in [vultisig/vultisig-windows](https://github.com/vultisig/vultisig-windows/releases/tag/v1.0.67).