### PR TITLE
downloads: update iOS/macOS to v1.41.65

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -26,7 +26,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "macos-github": {
-    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.40.63",
+    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.41.65",
     platform: "macos github",
     icon: "/images/macOS.svg",
     iconAlt: "MacOS Github",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -18,7 +18,7 @@ const hashes = [
   {
     os: "ios",
     icon: "/images/apple.svg",
-    hash: "sha256:5f4be1092f2fba41e11cb453bd637f4c0376daca1daad1ce881f81cd3980bcc8",
+    hash: "sha256:94d01f44d99210e1a4ab031e96975f08138f486284a81825582f13a7dcfc1dd1",
   },
   {
     os: "android",


### PR DESCRIPTION
## Summary
Updates the iOS/macOS download to release **v1.41.65**.

### Changes
- **macOS from GitHub link** (`app/downloads/Gtag.tsx`) → release tag `v1.41.65`
- **iOS SHA256 checksum** (`app/downloads/page.tsx`) → `94d01f44d99210e1a4ab031e96975f08138f486284a81825582f13a7dcfc1dd1`

Hash taken from the `digest` field of the `VultisigApp.v1.41.65.signed.pkg` asset in [vultisig/vultisig-ios](https://github.com/vultisig/vultisig-ios/releases/tag/v1.41.65).