### PR TITLE
downloads: update Android to v1.0.114

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.113",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.114",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:49ecbf312b461f4c4109732097a6dbb45fc5e77d43ddab7ec89e6da8e1166244",
+    hash: "sha256:c9685bab8a04d0299acb18ef9a6b083b75e3928fd4db8ac7e078308aa03eabb3",
   },
   {
     os: "linux",


### PR DESCRIPTION
## Summary
Updates the Android download to release **v1.0.114**.

### Changes
- **Android from GitHub link** (`app/downloads/Gtag.tsx`) → release tag `v1.0.114`
- **Android SHA256 checksum** (`app/downloads/page.tsx`) → `c9685bab8a04d0299acb18ef9a6b083b75e3928fd4db8ac7e078308aa03eabb3`

Hash taken from the `digest` field of the `v1.0.114.apk` asset in [vultisig/vultisig-android](https://github.com/vultisig/vultisig-android/releases/tag/v1.0.114).