### PR TITLE
downloads: update Windows and Linux to v1.0.68

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.67/Vultisig-amd64-installer-v1.0.67.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.68/Vultisig-amd64-installer-v1.0.68.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.67/vultisig_1.0.67_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.68/vultisig_1.0.68_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -28,12 +28,12 @@ const hashes = [
   {
     os: "linux",
     icon: "/images/linux.svg",
-    hash: "sha256:f8413d34c02e9d8737f14b237fde2c6a4d3dfe72425f6777185adb7e44843d8b",
+    hash: "sha256:53fc620282735e6be0917588ac8a06e99ca5b9fb4217dfef95e9d81b121fe218",
   },
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:11875299a204e6761754c583293d219353a1d981a654177ace300dbe387afa93",
+    hash: "sha256:355eb18b530e530b671b860fbd8c7c8372b9b487d7633b5f85c11ae7631c9738",
   },
 ]
 


### PR DESCRIPTION
## Summary
Updates the Windows and Linux desktop downloads to release **v1.0.68**.

### Changes
- **Download URLs** (`app/downloads/Gtag.tsx`)
  - Windows → `Vultisig-amd64-installer-v1.0.68.exe`
  - Linux → `vultisig_1.0.68_amd64.deb`
- **SHA256 checksums** (`app/downloads/page.tsx`)
  - Windows → `355eb18b530e530b671b860fbd8c7c8372b9b487d7633b5f85c11ae7631c9738`
  - Linux → `53fc620282735e6be0917588ac8a06e99ca5b9fb4217dfef95e9d81b121fe218`

Hashes taken from the `digest` field of the v1.0.68 assets in [vultisig/vultisig-windows](https://github.com/vultisig/vultisig-windows/releases/tag/v1.0.68).