### PR TITLE
downloads: update Android release to v1.0.115

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.114",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.115",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -23,7 +23,7 @@ const hashes = [
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:c9685bab8a04d0299acb18ef9a6b083b75e3928fd4db8ac7e078308aa03eabb3",
+    hash: "sha256:e4b2e1f4da1b7c836f358244831ce7d80b88dc0c3411f1b7ff2cd85746c01f67",
   },
   {
     os: "linux",


### PR DESCRIPTION
## Summary\n- update Android GitHub download channel from v1.0.114 to v1.0.115\n- update Android SHA256 checksum for the v1.0.115 APK\n\n## Validation\n- verified the release digest from the GitHub release API for tag v1.0.115