### PR TITLE
downloads: bump Android v1.0.116, iOS/macOS v1.43.69, Windows/Linux v1.0.69

### DIFF
--- a/app/downloads/Gtag.tsx
+++ b/app/downloads/Gtag.tsx
@@ -26,7 +26,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "macos-github": {
-    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.42.67",
+    href: "https://github.com/vultisig/vultisig-ios/releases/tag/v1.43.69",
     platform: "macos github",
     icon: "/images/macOS.svg",
     iconAlt: "MacOS Github",
@@ -44,7 +44,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   windows: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.68/Vultisig-amd64-installer-v1.0.68.exe",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.69/Vultisig-amd64-installer-v1.0.69.exe",
     platform: "windows",
     icon: "/images/windows.svg",
     iconAlt: "Windows",
@@ -53,7 +53,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   linux: {
-    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.68/vultisig_1.0.68_amd64.deb",
+    href: "https://github.com/vultisig/vultisig-windows/releases/download/v1.0.69/vultisig_1.0.69_amd64.deb",
     platform: "linux",
     icon: "/images/linux.svg",
     iconAlt: "Linux",
@@ -62,7 +62,7 @@ export const channels = {
     labelClass: "text-xs",
   },
   "android-github": {
-    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.115",
+    href: "https://github.com/vultisig/vultisig-android/releases/tag/v1.0.116",
     platform: "android github",
     icon: "/images/Android.svg",
     iconAlt: "Android",

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -18,22 +18,22 @@ const hashes = [
   {
     os: "ios",
     icon: "/images/apple.svg",
-    hash: "sha256:bb3e850f6f924040a2248c7073168c571d6e477e02736a2adc3787d212c53292",
+    hash: "sha256:2593a0ce32fe6b285b27dc0fd78664eaa03528a39231b8b677583a8094e8fd7b",
   },
   {
     os: "android",
     icon: "/images/Android.svg",
-    hash: "sha256:e4b2e1f4da1b7c836f358244831ce7d80b88dc0c3411f1b7ff2cd85746c01f67",
+    hash: "sha256:6409452465ae0cf96c894c9c64d6ce1830b7851ec380956becce962e82b4cb47",
   },
   {
     os: "linux",
     icon: "/images/linux.svg",
-    hash: "sha256:53fc620282735e6be0917588ac8a06e99ca5b9fb4217dfef95e9d81b121fe218",
+    hash: "sha256:6c6917efe5fe3b912833e93a542df37806ddbe85f94d1ec3933d65c4f5fffd6a",
   },
   {
     os: "windows",
     icon: "/images/windows.svg",
-    hash: "sha256:355eb18b530e530b671b860fbd8c7c8372b9b487d7633b5f85c11ae7631c9738",
+    hash: "sha256:e4e20aebae8f195f1439f904d13df9dcdfc92fb79fcd85f73bc1c90f80ce6051",
   },
 ]
 


### PR DESCRIPTION
## Summary
- Android: link + SHA256 → v1.0.116
- iOS/macOS: link + SHA256 → v1.43.69
- Windows/Linux: links + SHA256 → v1.0.69

Hashes taken from GitHub's asset digest via `gh release view --json assets` for each release.

## Test plan
- [ ] Verify download links resolve to the correct release assets
- [ ] Spot-check SHA256 values against the release pages